### PR TITLE
ported hecate to windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The Hex Editor From Hell!
 
 Usage:
 
-    go get -u launchpad.net/gommap
+    go get -u github.com/edsrzf/mmap-go
     go get -u github.com/nsf/termbox-go
     go build
     ./hecate /path/to/binary/file

--- a/hecate.go
+++ b/hecate.go
@@ -3,9 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
-	"syscall"
 
-	"launchpad.net/gommap"
+	mmap "github.com/edsrzf/mmap-go"
 
 	"github.com/nsf/termbox-go"
 )
@@ -19,12 +18,8 @@ func mainLoop(bytes []byte, style Style) {
 	for {
 		event := termbox.PollEvent()
 		if event.Type == termbox.EventKey {
-			if event.Key == termbox.KeyCtrlZ {
-				process, _ := os.FindProcess(os.Getpid())
-				termbox.Close()
-				process.Signal(syscall.SIGSTOP)
-				termbox.Init()
-			}
+			handleSpecialKeys(event.Key)
+
 			new_screen_index := display_screen.handleKeyEvent(event)
 			if new_screen_index < len(screens) {
 				display_screen = screens[new_screen_index]
@@ -65,7 +60,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	mm, err := gommap.MapRegion(file.Fd(), 0, fi.Size(), gommap.PROT_READ, gommap.MAP_SHARED)
+	mm, err := mmap.Map(file, mmap.RDONLY, 0)
 	if err != nil {
 		fmt.Printf("Error mmap'ing file: %q\n", err.Error())
 		os.Exit(1)

--- a/hecate_others.go
+++ b/hecate_others.go
@@ -1,0 +1,46 @@
+// +build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/nsf/termbox-go"
+)
+
+func handleSpecialKeys(key termbox.Key) {
+	if key == termbox.KeyCtrlZ {
+		process, _ := os.FindProcess(os.Getpid())
+		termbox.Close()
+		process.Signal(syscall.SIGSTOP)
+		termbox.Init()
+	}
+}
+
+const outputMode = termbox.Output256
+
+func defaultStyle() Style {
+	var style Style
+	style.default_bg = termbox.Attribute(1)
+	style.default_fg = termbox.Attribute(256)
+	style.rune_fg = termbox.Attribute(248)
+	style.int_fg = termbox.Attribute(154)
+	style.bit_fg = termbox.Attribute(154)
+	style.space_rune_fg = termbox.Attribute(240)
+
+	style.text_cursor_hex_bg = termbox.Attribute(167)
+	style.bit_cursor_hex_bg = termbox.Attribute(26)
+	style.int_cursor_hex_bg = termbox.Attribute(63)
+	style.fp_cursor_hex_bg = termbox.Attribute(127)
+
+	style.hilite_hex_fg = termbox.Attribute(231)
+	style.hilite_rune_fg = termbox.Attribute(256)
+
+	style.about_logo_bg = termbox.Attribute(125)
+
+	style.field_editor_bg = style.default_fg
+	style.field_editor_fg = style.default_bg
+
+	return style
+}

--- a/hecate_windows.go
+++ b/hecate_windows.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"github.com/nsf/termbox-go"
+)
+
+func handleSpecialKeys(key termbox.Key) {}
+
+const outputMode = termbox.OutputNormal
+
+func defaultStyle() Style {
+	var style Style
+	style.default_bg = termbox.ColorBlack
+	style.default_fg = termbox.ColorWhite
+	style.rune_fg = termbox.ColorYellow
+	style.int_fg = termbox.ColorCyan
+	style.bit_fg = termbox.ColorCyan
+	style.space_rune_fg = termbox.ColorWhite
+
+	style.text_cursor_hex_bg = termbox.ColorRed
+	style.bit_cursor_hex_bg = termbox.ColorCyan
+	style.int_cursor_hex_bg = termbox.ColorCyan
+	style.fp_cursor_hex_bg = termbox.ColorRed
+
+	style.hilite_hex_fg = termbox.ColorMagenta
+	style.hilite_rune_fg = termbox.ColorMagenta
+
+	style.about_logo_bg = termbox.ColorRed
+
+	style.field_editor_bg = style.default_fg
+	style.field_editor_fg = style.default_bg
+
+	return style
+}

--- a/screen_about.go
+++ b/screen_about.go
@@ -65,7 +65,7 @@ func (screen *AboutScreen) drawScreen(style Style) {
 			bg := default_bg
 			displayRune := ' '
 			if runeValue != ' ' {
-				bg = termbox.Attribute(125)
+				bg = style.about_logo_bg
 				if runeValue != '#' {
 					displayRune = runeValue
 				}

--- a/style.go
+++ b/style.go
@@ -23,27 +23,6 @@ type Style struct {
 
 	field_editor_bg termbox.Attribute
 	field_editor_fg termbox.Attribute
-}
 
-func defaultStyle() Style {
-	var style Style
-	style.default_bg = termbox.Attribute(1)
-	style.default_fg = termbox.Attribute(256)
-	style.rune_fg = termbox.Attribute(248)
-	style.int_fg = termbox.Attribute(154)
-	style.bit_fg = termbox.Attribute(154)
-	style.space_rune_fg = termbox.Attribute(240)
-
-	style.text_cursor_hex_bg = termbox.Attribute(167)
-	style.bit_cursor_hex_bg = termbox.Attribute(26)
-	style.int_cursor_hex_bg = termbox.Attribute(63)
-	style.fp_cursor_hex_bg = termbox.Attribute(127)
-
-	style.hilite_hex_fg = termbox.Attribute(231)
-	style.hilite_rune_fg = termbox.Attribute(256)
-
-	style.field_editor_bg = style.default_fg
-	style.field_editor_fg = style.default_bg
-
-	return style
+	about_logo_bg termbox.Attribute
 }


### PR DESCRIPTION
I did a fast port to windows. Therefor I had to change mmap lib, remove the SIGSTOP and most of all don't use 256 color mode in termbox (though the style could need some improvement...)
