### PR TITLE
new style configuration

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -3,8 +3,6 @@ package main
 import (
 	"fmt"
 	"math"
-
-	"github.com/nsf/termbox-go"
 )
 
 type CursorMode int
@@ -87,17 +85,18 @@ func (cursor Cursor) minimumLength() int {
 	return 1
 }
 
-func (cursor Cursor) color(style Style) termbox.Attribute {
+func (cursor Cursor) style(style *Style) *Style {
+	style = style.Sub("Cursor")
 	if cursor.mode == IntegerMode {
-		return style.int_cursor_hex_bg
+		return style.Sub("Int")
 	}
 	if cursor.mode == FloatingPointMode {
-		return style.fp_cursor_hex_bg
+		return style.Sub("Float")
 	}
 	if cursor.mode == BitPatternMode {
-		return style.bit_cursor_hex_bg
+		return style.Sub("Bit")
 	}
-	return style.text_cursor_hex_bg
+	return style.Sub("Text")
 }
 
 func (cursor Cursor) highlightRange(data []byte) ByteRange {

--- a/hecate.go
+++ b/hecate.go
@@ -11,7 +11,7 @@ import (
 
 const PROGRAM_NAME = "hecate"
 
-func mainLoop(bytes []byte, style Style) {
+func mainLoop(bytes []byte, style *Style) {
 	screens := defaultScreensForData(bytes)
 	display_screen := screens[DATA_SCREEN_INDEX]
 	layoutAndDrawScreen(display_screen, style)

--- a/hecate_others.go
+++ b/hecate_others.go
@@ -18,29 +18,87 @@ func handleSpecialKeys(key termbox.Key) {
 	}
 }
 
+func availableColors() []int {
+	result := make([]int, 256)
+	for i := 1; i <= 256; i++ {
+		result[i-1] = int(i)
+	}
+	return result
+}
+
 const outputMode = termbox.Output256
 
-func defaultStyle() Style {
-	var style Style
-	style.default_bg = termbox.Attribute(1)
-	style.default_fg = termbox.Attribute(256)
-	style.rune_fg = termbox.Attribute(248)
-	style.int_fg = termbox.Attribute(154)
-	style.bit_fg = termbox.Attribute(154)
-	style.space_rune_fg = termbox.Attribute(240)
+func defaultStyle() *Style {
+	style, err := StyleFromJson(`
+ {
+ 	"BG": 1,
+ 	"FG": 256,
+	"Data": {
+		"Hex": {
+			"Highlight": {
+				"FG": 231
+			}
+		},
 
-	style.text_cursor_hex_bg = termbox.Attribute(167)
-	style.bit_cursor_hex_bg = termbox.Attribute(26)
-	style.int_cursor_hex_bg = termbox.Attribute(63)
-	style.fp_cursor_hex_bg = termbox.Attribute(127)
+		"Rune": {
+			"FG": 248,
 
-	style.hilite_hex_fg = termbox.Attribute(231)
-	style.hilite_rune_fg = termbox.Attribute(256)
+			"Code": {
+				"FG": 240,
 
-	style.about_logo_bg = termbox.Attribute(125)
+				"Highlight": {
+					"FG": 248
+				}
+			},
 
-	style.field_editor_bg = style.default_fg
-	style.field_editor_fg = style.default_bg
+			"Highlight": {
+				"FG": 256
+			}
+		},
+
+		"Bit": {
+			"FG": 154
+		},
+
+		"Int": {
+			"FG": 154
+		},
+
+		"Cursor": {
+			"Int": {
+				"BG": 63
+			},
+			"Bit": {
+				"BG": 26
+			},
+			"Text": {
+				"BG": 167
+			},
+			"Float": {
+				"BG": 127
+			}
+		},
+
+		"Disabled": {
+			"FG": 240
+		},
+
+		"Edit": {
+			"BG": 256,
+ 			"FG": 1
+		}
+	},
+ 	"About": {
+ 		"Logo": {
+ 			"BG": 125
+ 		}
+ 	},
+ 	"Palette": {}
+ }`)
+
+	if err != nil {
+		panic(err)
+	}
 
 	return style
 }

--- a/hecate_windows.go
+++ b/hecate_windows.go
@@ -8,27 +8,85 @@ func handleSpecialKeys(key termbox.Key) {}
 
 const outputMode = termbox.OutputNormal
 
-func defaultStyle() Style {
-	var style Style
-	style.default_bg = termbox.ColorBlack
-	style.default_fg = termbox.ColorWhite
-	style.rune_fg = termbox.ColorYellow
-	style.int_fg = termbox.ColorCyan
-	style.bit_fg = termbox.ColorCyan
-	style.space_rune_fg = termbox.ColorWhite
+func availableColors() []int {
+	result := make([]int, int(termbox.ColorWhite))
+	for i := termbox.ColorBlack; i <= termbox.ColorWhite; i++ {
+		result[i-termbox.ColorBlack] = int(i)
+	}
+	return result
+}
 
-	style.text_cursor_hex_bg = termbox.ColorRed
-	style.bit_cursor_hex_bg = termbox.ColorCyan
-	style.int_cursor_hex_bg = termbox.ColorCyan
-	style.fp_cursor_hex_bg = termbox.ColorRed
+func defaultStyle() *Style {
+	style, err := StyleFromJson(`
+ {
+ 	"BG": 1,
+ 	"FG": 8,
+	"Data": {
+		"Hex": {
+			"Highlight": {
+				"FG": 6
+			}
+		},
 
-	style.hilite_hex_fg = termbox.ColorMagenta
-	style.hilite_rune_fg = termbox.ColorMagenta
+		"Rune": {
+			"FG": 4,
 
-	style.about_logo_bg = termbox.ColorRed
+			"Code": {
+				"FG": 8,
 
-	style.field_editor_bg = style.default_fg
-	style.field_editor_fg = style.default_bg
+				"Highlight": {
+					"FG": 4
+				}
+			},
+
+			"Highlight": {
+				"FG": 8
+			}
+		},
+
+		"Bit": {
+			"FG": 7
+		},
+
+		"Int": {
+			"FG": 7
+		},
+
+		"Cursor": {
+			"Int": {
+				"BG": 7
+			},
+			"Bit": {
+				"BG": 7
+			},
+			"Text": {
+				"BG": 2
+			},
+			"Float": {
+				"BG": 2
+			}
+		},
+
+		"Disabled": {
+			"FG": 8
+		},
+
+		"Edit": {
+			"BG": 8,
+ 			"FG": 1
+		}
+	},
+ 	"About": {
+ 		"Logo": {
+ 			"BG": 2
+ 		}
+ 	},
+ 	"Palette": {}
+ }`)
+
+	if err != nil {
+		panic(err)
+	}
 
 	return style
 }

--- a/screen.go
+++ b/screen.go
@@ -7,7 +7,7 @@ import (
 type Screen interface {
 	handleKeyEvent(event termbox.Event) int
 	performLayout()
-	drawScreen(style Style)
+	drawScreen(style *Style)
 }
 
 const (
@@ -42,9 +42,9 @@ func drawBackground(bg termbox.Attribute) {
 	termbox.Clear(0, bg)
 }
 
-func layoutAndDrawScreen(screen Screen, style Style) {
+func layoutAndDrawScreen(screen Screen, style *Style) {
 	screen.performLayout()
-	drawBackground(style.default_bg)
+	drawBackground(style.Bg())
 	screen.drawScreen(style)
 	termbox.Flush()
 }

--- a/screen_about.go
+++ b/screen_about.go
@@ -16,8 +16,8 @@ type AboutScreen int
 func drawCommandsAtPoint(commands []Command, x int, y int, style *Style) {
 	x_pos, y_pos := x, y
 	for index, cmd := range commands {
-		style.StringOut(fmt.Sprintf("%6s", cmd.key), x_pos, y_pos)
-		style.StringOut(cmd.description, x_pos+8, y_pos)
+		StringOut(fmt.Sprintf("%6s", cmd.key), x_pos, y_pos, style)
+		StringOut(cmd.description, x_pos+8, y_pos, style)
 		y_pos++
 		if index > 2 && index%2 == 1 {
 			y_pos++
@@ -71,7 +71,7 @@ func (screen *AboutScreen) drawScreen(style *Style) {
 				if runeValue != '#' {
 					displayRune = runeValue
 				}
-				s.SetCell(x_pos, y_pos, displayRune)
+				SetCell(x_pos, y_pos, displayRune, s)
 			}
 			x_pos++
 		}

--- a/screen_about.go
+++ b/screen_about.go
@@ -13,11 +13,11 @@ type Command struct {
 
 type AboutScreen int
 
-func drawCommandsAtPoint(commands []Command, x int, y int, style Style) {
+func drawCommandsAtPoint(commands []Command, x int, y int, style *Style) {
 	x_pos, y_pos := x, y
 	for index, cmd := range commands {
-		drawStringAtPoint(fmt.Sprintf("%6s", cmd.key), x_pos, y_pos, style.default_fg, style.default_bg)
-		drawStringAtPoint(cmd.description, x_pos+8, y_pos, style.default_fg, style.default_bg)
+		style.StringOut(fmt.Sprintf("%6s", cmd.key), x_pos, y_pos)
+		style.StringOut(cmd.description, x_pos+8, y_pos)
 		y_pos++
 		if index > 2 && index%2 == 1 {
 			y_pos++
@@ -32,9 +32,10 @@ func (screen *AboutScreen) handleKeyEvent(event termbox.Event) int {
 func (screen *AboutScreen) performLayout() {
 }
 
-func (screen *AboutScreen) drawScreen(style Style) {
-	default_fg := style.default_fg
-	default_bg := style.default_bg
+func (screen *AboutScreen) drawScreen(style *Style) {
+	style = style.Sub("About")
+	logo := style.Sub("Logo")
+
 	width, height := termbox.Size()
 	template := [...]string{
 		"                              ############################",
@@ -62,14 +63,15 @@ func (screen *AboutScreen) drawScreen(style Style) {
 	for _, line := range template {
 		x_pos = start_x
 		for _, runeValue := range line {
-			bg := default_bg
+			s := style
+
 			displayRune := ' '
 			if runeValue != ' ' {
-				bg = style.about_logo_bg
+				s = logo
 				if runeValue != '#' {
 					displayRune = runeValue
 				}
-				termbox.SetCell(x_pos, y_pos, displayRune, default_fg, bg)
+				s.SetCell(x_pos, y_pos, displayRune)
 			}
 			x_pos++
 		}

--- a/screen_data.go
+++ b/screen_data.go
@@ -192,8 +192,8 @@ func (screen *DataScreen) drawScreen(style *Style) {
 		}
 		if index >= cursor.pos && index < cursor.pos+cursor_length {
 			hex = cursor.style(style)
-			hex.SetCell(x-1, y, ' ')
-			hex.SetCell(x+2, y, ' ')
+			SetCell(x-1, y, ' ', hex)
+			SetCell(x+2, y, ' ', hex)
 		} else if index >= hilite.pos && index < hilite.pos+hilite.length {
 			hex = hex.Sub("Highlight")
 		}
@@ -205,27 +205,27 @@ func (screen *DataScreen) drawScreen(style *Style) {
 
 		if cursor.mode == StringMode || index < cursor.pos || index >= cursor.pos+cursor_length {
 			if b == 0x20 {
-				code.SetCell(x, y+1, '•')
+				SetCell(x, y+1, '•', code)
 			} else if isASCII(b) {
-				txt.SetCell(x, y+1, rune(b))
+				SetCell(x, y+1, rune(b), txt)
 			} else if isCode(b) {
 				codes := map[byte]rune{
 					0x0A: 'n',
 					0x0D: 'r',
 					0x09: 't',
 				}
-				code.SetCell(x, y+1, '\\')
-				code.SetCell(x+1, y+1, codes[b])
+				SetCell(x, y+1, '\\', code)
+				SetCell(x+1, y+1, codes[b], code)
 			} else {
-				txt.SetCell(x, y+1, ' ')
+				SetCell(x, y+1, ' ', txt)
 			}
 		} else if cursor.mode == BitPatternMode {
 			bit := style.Sub("Bit")
 			for i := 0; i < 8; i++ {
 				if b&(1<<uint8(7-i)) > 0 {
-					bit.SetCell(x-1+(i%4), y+1+i/4, '●')
+					SetCell(x-1+(i%4), y+1+i/4, '●', bit)
 				} else {
-					bit.SetCell(x-1+(i%4), y+1+i/4, '○')
+					SetCell(x-1+(i%4), y+1+i/4, '○', bit)
 				}
 			}
 		} else if index == cursor.pos {
@@ -243,7 +243,7 @@ func (screen *DataScreen) drawScreen(style *Style) {
 				if y_copy > last_y {
 					break
 				}
-				intstyle.SetCell(x_copy, y_copy, runeValue)
+				SetCell(x_copy, y_copy, runeValue, intstyle)
 				x_copy++
 				if x_copy > last_x {
 					x_copy = x_pad
@@ -252,7 +252,7 @@ func (screen *DataScreen) drawScreen(style *Style) {
 			}
 		}
 		str := fmt.Sprintf("%02x", b)
-		x += hex.StringOut(str, x, y)
+		x += StringOut(str, x, y, hex)
 		x++
 	}
 
@@ -265,6 +265,6 @@ func (screen *DataScreen) drawScreen(style *Style) {
 			y = height - widget_height - 1
 		}
 		termbox.SetCursor(x+2+screen.field_editor.cursor_pos, y)
-		style.Sub("Edit").StringOut(fmt.Sprintf(" %-8s ", screen.field_editor.value), x+1, y)
+		StringOut(fmt.Sprintf(" %-8s ", screen.field_editor.value), x+1, y, style.Sub("Edit"))
 	}
 }

--- a/screen_data.go
+++ b/screen_data.go
@@ -157,7 +157,8 @@ func (screen *DataScreen) performLayout() {
 	screen.view_port = new_view_port
 }
 
-func (screen *DataScreen) drawScreen(style Style) {
+func (screen *DataScreen) drawScreen(style *Style) {
+	style = style.Sub("Data")
 	x, y := 2, 1
 	x_pad := 2
 	line_height := 3
@@ -177,11 +178,10 @@ func (screen *DataScreen) drawScreen(style Style) {
 	end := start + view_port.number_of_rows*view_port.bytes_per_row
 	for index := start; index < end && index < len(screen.bytes); index++ {
 		b := screen.bytes[index]
-		hex_fg := style.default_fg
-		hex_bg := style.default_bg
-		code_fg := style.space_rune_fg
-		rune_fg := style.rune_fg
-		rune_bg := style.default_bg
+		hex := style.Sub("Hex")
+		txt := style.Sub("Rune")
+		code := txt.Sub("Code")
+
 		cursor_length := cursor.length()
 		if index%view_port.bytes_per_row == 0 {
 			x = x_pad
@@ -191,38 +191,41 @@ func (screen *DataScreen) drawScreen(style Style) {
 			break
 		}
 		if index >= cursor.pos && index < cursor.pos+cursor_length {
-			hex_bg = cursor.color(style)
-			termbox.SetCell(x-1, y, ' ', hex_fg, hex_bg)
-			termbox.SetCell(x+2, y, ' ', hex_fg, hex_bg)
+			hex = cursor.style(style)
+			hex.SetCell(x-1, y, ' ')
+			hex.SetCell(x+2, y, ' ')
 		} else if index >= hilite.pos && index < hilite.pos+hilite.length {
-			hex_fg = style.hilite_hex_fg
+			hex = hex.Sub("Highlight")
 		}
+
 		if index >= hilite.pos && index < hilite.pos+hilite.length {
-			rune_fg = style.hilite_rune_fg
-			code_fg = style.rune_fg
+			txt = txt.Sub("Highlight")
+			code = code.Sub("Highlight")
 		}
+
 		if cursor.mode == StringMode || index < cursor.pos || index >= cursor.pos+cursor_length {
 			if b == 0x20 {
-				termbox.SetCell(x, y+1, '•', style.space_rune_fg, rune_bg)
+				code.SetCell(x, y+1, '•')
 			} else if isASCII(b) {
-				termbox.SetCell(x, y+1, rune(b), rune_fg, rune_bg)
+				txt.SetCell(x, y+1, rune(b))
 			} else if isCode(b) {
 				codes := map[byte]rune{
 					0x0A: 'n',
 					0x0D: 'r',
 					0x09: 't',
 				}
-				termbox.SetCell(x, y+1, '\\', code_fg, rune_bg)
-				termbox.SetCell(x+1, y+1, codes[b], code_fg, rune_bg)
+				code.SetCell(x, y+1, '\\')
+				code.SetCell(x+1, y+1, codes[b])
 			} else {
-				termbox.SetCell(x, y+1, ' ', 0, rune_bg)
+				txt.SetCell(x, y+1, ' ')
 			}
 		} else if cursor.mode == BitPatternMode {
+			bit := style.Sub("Bit")
 			for i := 0; i < 8; i++ {
 				if b&(1<<uint8(7-i)) > 0 {
-					termbox.SetCell(x-1+(i%4), y+1+i/4, '●', style.bit_fg, rune_bg)
+					bit.SetCell(x-1+(i%4), y+1+i/4, '●')
 				} else {
-					termbox.SetCell(x-1+(i%4), y+1+i/4, '○', style.bit_fg, rune_bg)
+					bit.SetCell(x-1+(i%4), y+1+i/4, '○')
 				}
 			}
 		} else if index == cursor.pos {
@@ -235,11 +238,12 @@ func (screen *DataScreen) drawScreen(style Style) {
 				x_copy = (x_copy % (width - x_pad)) + x_pad
 				y_copy += line_height
 			}
+			intstyle := style.Sub("Int")
 			for _, runeValue := range str {
 				if y_copy > last_y {
 					break
 				}
-				termbox.SetCell(x_copy, y_copy, runeValue, style.int_fg, rune_bg)
+				intstyle.SetCell(x_copy, y_copy, runeValue)
 				x_copy++
 				if x_copy > last_x {
 					x_copy = x_pad
@@ -248,7 +252,7 @@ func (screen *DataScreen) drawScreen(style Style) {
 			}
 		}
 		str := fmt.Sprintf("%02x", b)
-		x += drawStringAtPoint(str, x, y, hex_fg, hex_bg)
+		x += hex.StringOut(str, x, y)
 		x++
 	}
 
@@ -261,7 +265,6 @@ func (screen *DataScreen) drawScreen(style Style) {
 			y = height - widget_height - 1
 		}
 		termbox.SetCursor(x+2+screen.field_editor.cursor_pos, y)
-		drawStringAtPoint(fmt.Sprintf(" %-8s ", screen.field_editor.value), x+1, y,
-			style.field_editor_fg, style.field_editor_bg)
+		style.Sub("Edit").StringOut(fmt.Sprintf(" %-8s ", screen.field_editor.value), x+1, y)
 	}
 }

--- a/screen_palette.go
+++ b/screen_palette.go
@@ -32,7 +32,7 @@ func (screen *PaletteScreen) drawScreen(style *Style) {
 		x += 2
 
 		str := fmt.Sprintf("%3d", color)
-		x += style.StringOut(str, x, y)
+		x += StringOut(str, x, y, style)
 		x += 2
 	}
 }

--- a/screen_palette.go
+++ b/screen_palette.go
@@ -14,11 +14,11 @@ func (screen *PaletteScreen) handleKeyEvent(event termbox.Event) int {
 func (screen *PaletteScreen) performLayout() {
 }
 
-func (screen *PaletteScreen) drawScreen(style Style) {
+func (screen *PaletteScreen) drawScreen(style *Style) {
+	style = style.Sub("Palette")
 	width, height := termbox.Size()
-	fg, bg := style.default_fg, style.default_bg
 	x, y := 2, 1
-	for color := 1; color <= 256; color++ {
+	for _, color := range availableColors() {
 		if x+8 > width {
 			x = 2
 			y += 2
@@ -32,7 +32,7 @@ func (screen *PaletteScreen) drawScreen(style Style) {
 		x += 2
 
 		str := fmt.Sprintf("%3d", color)
-		x += drawStringAtPoint(str, x, y, fg, bg)
+		x += style.StringOut(str, x, y)
 		x += 2
 	}
 }

--- a/string_util.go
+++ b/string_util.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"unicode/utf8"
-
-	"github.com/nsf/termbox-go"
 )
 
 func isASCII(val byte) bool {
@@ -16,15 +14,6 @@ func isCode(val byte) bool {
 
 func isPrintable(val byte) bool {
 	return isASCII(val) || isCode(val)
-}
-
-func drawStringAtPoint(str string, x int, y int, fg termbox.Attribute, bg termbox.Attribute) int {
-	x_pos := x
-	for _, runeValue := range str {
-		termbox.SetCell(x_pos, y, runeValue, fg, bg)
-		x_pos++
-	}
-	return x_pos - x
 }
 
 func removeRuneAtIndex(value []byte, index int) []byte {

--- a/string_util.go
+++ b/string_util.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/nsf/termbox-go"
 	"unicode/utf8"
 )
 
@@ -52,4 +53,18 @@ func insertRuneAtIndex(value []byte, index int, newRuneValue rune) []byte {
 		pos += utf8.EncodeRune(new_string[pos:], runeValue)
 	}
 	return new_string[0:pos]
+}
+
+func SetCell(x, y int, ch rune, s *Style) {
+	termbox.SetCell(x, y, ch, s.Fg(), s.Bg())
+}
+
+func StringOut(str string, x, y int, s *Style) int {
+	x_pos := x
+	fg, bg := s.Fg(), s.Bg()
+	for _, runeValue := range str {
+		termbox.SetCell(x_pos, y, runeValue, fg, bg)
+		x_pos++
+	}
+	return x_pos - x
 }

--- a/style.go
+++ b/style.go
@@ -1,28 +1,101 @@
 package main
 
 import (
+	"encoding/json"
 	"github.com/nsf/termbox-go"
 )
 
 type Style struct {
-	default_bg termbox.Attribute
-	default_fg termbox.Attribute
+	parent *Style
+	bg     *termbox.Attribute
+	fg     *termbox.Attribute
+	childs map[string]*Style
+}
 
-	rune_fg       termbox.Attribute
-	space_rune_fg termbox.Attribute
-	int_fg        termbox.Attribute
-	bit_fg        termbox.Attribute
+func (s *Style) Bg() termbox.Attribute {
+	for s != nil {
+		if s.bg != nil {
+			return *s.bg
+		}
+		s = s.parent
+	}
+	return 0
+}
 
-	text_cursor_hex_bg termbox.Attribute
-	bit_cursor_hex_bg  termbox.Attribute
-	int_cursor_hex_bg  termbox.Attribute
-	fp_cursor_hex_bg   termbox.Attribute
+func (s *Style) Fg() termbox.Attribute {
+	for s != nil {
+		if s.fg != nil {
+			return *s.fg
+		}
+		s = s.parent
+	}
+	return 0
+}
 
-	hilite_hex_fg  termbox.Attribute
-	hilite_rune_fg termbox.Attribute
+func (s *Style) Sub(name ...string) *Style {
+	if len(name) > 0 {
+		c, ok := s.childs[name[0]]
+		if ok {
+			return c.Sub(name[1:]...)
+		}
+	}
+	return s
+}
 
-	field_editor_bg termbox.Attribute
-	field_editor_fg termbox.Attribute
+func (s *Style) SetCell(x, y int, ch rune) {
+	termbox.SetCell(x, y, ch, s.Fg(), s.Bg())
+}
 
-	about_logo_bg termbox.Attribute
+func (s *Style) StringOut(str string, x, y int) int {
+	x_pos := x
+	fg, bg := s.Fg(), s.Bg()
+	for _, runeValue := range str {
+		termbox.SetCell(x_pos, y, runeValue, fg, bg)
+		x_pos++
+	}
+	return x_pos - x
+}
+
+func (s *Style) UnmarshalJSON(data []byte) error {
+	raw := make(map[string]json.RawMessage)
+
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
+		return nil
+	}
+	if fg, ok := raw["FG"]; ok {
+		delete(raw, "FG")
+		f := new(termbox.Attribute)
+		if err = json.Unmarshal(fg, f); err != nil {
+			return err
+		}
+		s.fg = f
+	}
+	if bg, ok := raw["BG"]; ok {
+		delete(raw, "BG")
+		f := new(termbox.Attribute)
+		if err = json.Unmarshal(bg, f); err != nil {
+			return err
+		}
+		s.bg = f
+	}
+
+	for k, v := range raw {
+		if s.childs == nil {
+			s.childs = make(map[string]*Style)
+		}
+		sub := new(Style)
+		if err := json.Unmarshal(v, sub); err != nil {
+			return err
+		}
+		s.childs[k] = sub
+		sub.parent = s
+	}
+	return nil
+}
+
+func StyleFromJson(js string) (*Style, error) {
+	style := new(Style)
+	err := json.Unmarshal([]byte(js), style)
+	return style, err
 }

--- a/style.go
+++ b/style.go
@@ -19,7 +19,7 @@ func (s *Style) Bg() termbox.Attribute {
 		}
 		s = s.parent
 	}
-	return 0
+	return termbox.ColorDefault
 }
 
 func (s *Style) Fg() termbox.Attribute {
@@ -29,7 +29,7 @@ func (s *Style) Fg() termbox.Attribute {
 		}
 		s = s.parent
 	}
-	return 0
+	return termbox.ColorDefault
 }
 
 func (s *Style) Sub(name ...string) *Style {
@@ -40,20 +40,6 @@ func (s *Style) Sub(name ...string) *Style {
 		}
 	}
 	return s
-}
-
-func (s *Style) SetCell(x, y int, ch rune) {
-	termbox.SetCell(x, y, ch, s.Fg(), s.Bg())
-}
-
-func (s *Style) StringOut(str string, x, y int) int {
-	x_pos := x
-	fg, bg := s.Fg(), s.Bg()
-	for _, runeValue := range str {
-		termbox.SetCell(x_pos, y, runeValue, fg, bg)
-		x_pos++
-	}
-	return x_pos - x
 }
 
 func (s *Style) UnmarshalJSON(data []byte) error {

--- a/widget.go
+++ b/widget.go
@@ -6,7 +6,7 @@ import (
 
 type Widget interface {
 	layoutUnderPressure(pressure int) (int, int)
-	drawAtPoint(cursor Cursor, x int, y int, pressure int, style Style) (int, int)
+	drawAtPoint(cursor Cursor, x int, y int, pressure int, style *Style) (int, int)
 }
 
 type WidgetSlice []Widget
@@ -70,7 +70,7 @@ func heightOfWidgets() int {
 	return max_widget_height
 }
 
-func drawWidgets(cursor Cursor, style Style) (int, int) {
+func drawWidgets(cursor Cursor, style *Style) (int, int) {
 	widgets := listOfWidgets()
 
 	width, height := termbox.Size()

--- a/widget_cursor.go
+++ b/widget_cursor.go
@@ -38,12 +38,12 @@ func (widget CursorWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int
 	disabled := style.Sub("Disabled")
 
 	if pressure < 5 || pressure == 6 {
-		x_pos += style.StringOut("Cursor: ", x_pos, y_pos)
+		x_pos += StringOut("Cursor: ", x_pos, y_pos, style)
 	}
 	if cursor.mode == StringMode {
-		x_pos += cursorstyle.StringOut("(t)ext", x_pos, y_pos)
+		x_pos += StringOut("(t)ext", x_pos, y_pos, cursorstyle)
 	} else {
-		x_pos += style.StringOut("(t)ext", x_pos, y_pos)
+		x_pos += StringOut("(t)ext", x_pos, y_pos, style)
 	}
 	if pressure < 6 {
 		x_pos++
@@ -54,9 +54,9 @@ func (widget CursorWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int
 		y_pos++
 	}
 	if cursor.mode == BitPatternMode {
-		x_pos += cursorstyle.StringOut("(p)attern", x_pos, y_pos)
+		x_pos += StringOut("(p)attern", x_pos, y_pos, cursorstyle)
 	} else {
-		x_pos += style.StringOut("(p)attern", x_pos, y_pos)
+		x_pos += StringOut("(p)attern", x_pos, y_pos, style)
 	}
 	if pressure < 6 {
 		x_pos++
@@ -68,9 +68,9 @@ func (widget CursorWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int
 		y_pos++
 	}
 	if cursor.mode == IntegerMode {
-		x_pos += cursorstyle.StringOut("(i)nteger", x_pos, y_pos)
+		x_pos += StringOut("(i)nteger", x_pos, y_pos, cursorstyle)
 	} else {
-		x_pos += style.StringOut("(i)nteger", x_pos, y_pos)
+		x_pos += StringOut("(i)nteger", x_pos, y_pos, style)
 	}
 	if pressure < 8 {
 		x_pos++
@@ -79,17 +79,17 @@ func (widget CursorWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int
 		y_pos++
 	}
 	if cursor.mode == FloatingPointMode {
-		x_pos += cursorstyle.StringOut("(f)loat", x_pos, y_pos)
+		x_pos += StringOut("(f)loat", x_pos, y_pos, cursorstyle)
 	} else {
-		x_pos += style.StringOut("(f)loat", x_pos, y_pos)
+		x_pos += StringOut("(f)loat", x_pos, y_pos, style)
 	}
 	x_pos = x
 	y_pos++
 	if pressure < 5 || pressure == 6 {
 		if cursor.mode == IntegerMode || cursor.mode == FloatingPointMode {
-			x_pos += style.StringOut("Toggle: ", x_pos, y_pos)
+			x_pos += StringOut("Toggle: ", x_pos, y_pos, style)
 		} else {
-			x_pos += disabled.StringOut("Toggle: ", x_pos, y_pos)
+			x_pos += StringOut("Toggle: ", x_pos, y_pos, disabled)
 		}
 	}
 	if pressure >= 8 {
@@ -97,13 +97,13 @@ func (widget CursorWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int
 	}
 	if cursor.mode == IntegerMode || cursor.mode == FloatingPointMode {
 		if cursor.big_endian {
-			x_pos += style.StringOut("(E)ndian", x_pos, y_pos)
+			x_pos += StringOut("(E)ndian", x_pos, y_pos, style)
 		} else {
-			x_pos += style.StringOut("(e)ndian", x_pos, y_pos)
+			x_pos += StringOut("(e)ndian", x_pos, y_pos, style)
 		}
 		x_pos++
 	} else if cursor.mode == BitPatternMode || cursor.mode == StringMode {
-		x_pos += disabled.StringOut("(e)ndian", x_pos, y_pos)
+		x_pos += StringOut("(e)ndian", x_pos, y_pos, disabled)
 		x_pos++
 	}
 	if pressure >= 8 {
@@ -114,29 +114,29 @@ func (widget CursorWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int
 	}
 	if cursor.mode == IntegerMode {
 		if cursor.unsigned {
-			x_pos += style.StringOut("(U)nsigned", x_pos, y_pos)
+			x_pos += StringOut("(U)nsigned", x_pos, y_pos, style)
 		} else {
-			x_pos += style.StringOut("(u)nsigned", x_pos, y_pos)
+			x_pos += StringOut("(u)nsigned", x_pos, y_pos, style)
 		}
 	} else {
-		x_pos += disabled.StringOut("(u)nsigned", x_pos, y_pos)
+		x_pos += StringOut("(u)nsigned", x_pos, y_pos, disabled)
 	}
 	if pressure < 6 {
 		x_pos += 4
 		if cursor.mode == IntegerMode || cursor.mode == FloatingPointMode {
-			x_pos += style.StringOut("Size:", x_pos, y_pos)
+			x_pos += StringOut("Size:", x_pos, y_pos, style)
 			if cursor.length() > cursor.minimumLength() {
-				x_pos += style.StringOut(" ←H", x_pos, y_pos)
+				x_pos += StringOut(" ←H", x_pos, y_pos, style)
 			} else {
-				x_pos += disabled.StringOut(" ←H", x_pos, y_pos)
+				x_pos += StringOut(" ←H", x_pos, y_pos, disabled)
 			}
 			if cursor.length() < cursor.maximumLength() {
-				x_pos += style.StringOut(" →L", x_pos, y_pos)
+				x_pos += StringOut(" →L", x_pos, y_pos, style)
 			} else {
-				x_pos += disabled.StringOut(" →L", x_pos, y_pos)
+				x_pos += StringOut(" →L", x_pos, y_pos, disabled)
 			}
 		} else {
-			x_pos += disabled.StringOut("Size: ←H →L", x_pos, y_pos)
+			x_pos += StringOut("Size: ←H →L", x_pos, y_pos, disabled)
 		}
 	}
 	return x_pos - x, y_pos - y + 1

--- a/widget_cursor.go
+++ b/widget_cursor.go
@@ -30,18 +30,20 @@ func (widget CursorWidget) layoutUnderPressure(pressure int) (int, int) {
 	return runeCount, height
 }
 
-func (widget CursorWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int, style Style) (int, int) {
-	fg := style.default_fg
-	bg := style.default_bg
+func (widget CursorWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int, style *Style) (int, int) {
 	x_pos := x
 	y_pos := y
+
+	cursorstyle := cursor.style(style)
+	disabled := style.Sub("Disabled")
+
 	if pressure < 5 || pressure == 6 {
-		x_pos += drawStringAtPoint("Cursor: ", x_pos, y_pos, fg, bg)
+		x_pos += style.StringOut("Cursor: ", x_pos, y_pos)
 	}
 	if cursor.mode == StringMode {
-		x_pos += drawStringAtPoint("(t)ext", x_pos, y_pos, fg, cursor.color(style))
+		x_pos += cursorstyle.StringOut("(t)ext", x_pos, y_pos)
 	} else {
-		x_pos += drawStringAtPoint("(t)ext", x_pos, y_pos, fg, bg)
+		x_pos += style.StringOut("(t)ext", x_pos, y_pos)
 	}
 	if pressure < 6 {
 		x_pos++
@@ -52,9 +54,9 @@ func (widget CursorWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int
 		y_pos++
 	}
 	if cursor.mode == BitPatternMode {
-		x_pos += drawStringAtPoint("(p)attern", x_pos, y_pos, fg, cursor.color(style))
+		x_pos += cursorstyle.StringOut("(p)attern", x_pos, y_pos)
 	} else {
-		x_pos += drawStringAtPoint("(p)attern", x_pos, y_pos, fg, bg)
+		x_pos += style.StringOut("(p)attern", x_pos, y_pos)
 	}
 	if pressure < 6 {
 		x_pos++
@@ -66,9 +68,9 @@ func (widget CursorWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int
 		y_pos++
 	}
 	if cursor.mode == IntegerMode {
-		x_pos += drawStringAtPoint("(i)nteger", x_pos, y_pos, fg, cursor.color(style))
+		x_pos += cursorstyle.StringOut("(i)nteger", x_pos, y_pos)
 	} else {
-		x_pos += drawStringAtPoint("(i)nteger", x_pos, y_pos, fg, bg)
+		x_pos += style.StringOut("(i)nteger", x_pos, y_pos)
 	}
 	if pressure < 8 {
 		x_pos++
@@ -77,17 +79,17 @@ func (widget CursorWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int
 		y_pos++
 	}
 	if cursor.mode == FloatingPointMode {
-		x_pos += drawStringAtPoint("(f)loat", x_pos, y_pos, fg, cursor.color(style))
+		x_pos += cursorstyle.StringOut("(f)loat", x_pos, y_pos)
 	} else {
-		x_pos += drawStringAtPoint("(f)loat", x_pos, y_pos, fg, bg)
+		x_pos += style.StringOut("(f)loat", x_pos, y_pos)
 	}
 	x_pos = x
 	y_pos++
 	if pressure < 5 || pressure == 6 {
 		if cursor.mode == IntegerMode || cursor.mode == FloatingPointMode {
-			x_pos += drawStringAtPoint("Toggle: ", x_pos, y_pos, fg, bg)
+			x_pos += style.StringOut("Toggle: ", x_pos, y_pos)
 		} else {
-			x_pos += drawStringAtPoint("Toggle: ", x_pos, y_pos, style.space_rune_fg, bg)
+			x_pos += disabled.StringOut("Toggle: ", x_pos, y_pos)
 		}
 	}
 	if pressure >= 8 {
@@ -95,13 +97,13 @@ func (widget CursorWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int
 	}
 	if cursor.mode == IntegerMode || cursor.mode == FloatingPointMode {
 		if cursor.big_endian {
-			x_pos += drawStringAtPoint("(E)ndian", x_pos, y_pos, fg, bg)
+			x_pos += style.StringOut("(E)ndian", x_pos, y_pos)
 		} else {
-			x_pos += drawStringAtPoint("(e)ndian", x_pos, y_pos, fg, bg)
+			x_pos += style.StringOut("(e)ndian", x_pos, y_pos)
 		}
 		x_pos++
 	} else if cursor.mode == BitPatternMode || cursor.mode == StringMode {
-		x_pos += drawStringAtPoint("(e)ndian", x_pos, y_pos, style.space_rune_fg, bg)
+		x_pos += disabled.StringOut("(e)ndian", x_pos, y_pos)
 		x_pos++
 	}
 	if pressure >= 8 {
@@ -112,29 +114,29 @@ func (widget CursorWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int
 	}
 	if cursor.mode == IntegerMode {
 		if cursor.unsigned {
-			x_pos += drawStringAtPoint("(U)nsigned", x_pos, y_pos, fg, bg)
+			x_pos += style.StringOut("(U)nsigned", x_pos, y_pos)
 		} else {
-			x_pos += drawStringAtPoint("(u)nsigned", x_pos, y_pos, fg, bg)
+			x_pos += style.StringOut("(u)nsigned", x_pos, y_pos)
 		}
 	} else {
-		x_pos += drawStringAtPoint("(u)nsigned", x_pos, y_pos, style.space_rune_fg, bg)
+		x_pos += disabled.StringOut("(u)nsigned", x_pos, y_pos)
 	}
 	if pressure < 6 {
 		x_pos += 4
 		if cursor.mode == IntegerMode || cursor.mode == FloatingPointMode {
-			x_pos += drawStringAtPoint("Size:", x_pos, y_pos, fg, bg)
+			x_pos += style.StringOut("Size:", x_pos, y_pos)
 			if cursor.length() > cursor.minimumLength() {
-				x_pos += drawStringAtPoint(" ←H", x_pos, y_pos, fg, bg)
+				x_pos += style.StringOut(" ←H", x_pos, y_pos)
 			} else {
-				x_pos += drawStringAtPoint(" ←H", x_pos, y_pos, style.space_rune_fg, bg)
+				x_pos += disabled.StringOut(" ←H", x_pos, y_pos)
 			}
 			if cursor.length() < cursor.maximumLength() {
-				x_pos += drawStringAtPoint(" →L", x_pos, y_pos, fg, bg)
+				x_pos += style.StringOut(" →L", x_pos, y_pos)
 			} else {
-				x_pos += drawStringAtPoint(" →L", x_pos, y_pos, style.space_rune_fg, bg)
+				x_pos += disabled.StringOut(" →L", x_pos, y_pos)
 			}
 		} else {
-			x_pos += drawStringAtPoint("Size: ←H →L", x_pos, y_pos, style.space_rune_fg, bg)
+			x_pos += disabled.StringOut("Size: ←H →L", x_pos, y_pos)
 		}
 	}
 	return x_pos - x, y_pos - y + 1

--- a/widget_nav.go
+++ b/widget_nav.go
@@ -17,18 +17,16 @@ func (widget NavigationWidget) layoutUnderPressure(pressure int) (int, int) {
 	return runeCount, 2
 }
 
-func (widget NavigationWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int, style Style) (int, int) {
-	fg := style.default_fg
-	bg := style.default_bg
+func (widget NavigationWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int, style *Style) (int, int) {
 	x_pos := x
 	if pressure == 0 {
-		x_pos += drawStringAtPoint("Navigate: ←h ↓j ↑k →l", x_pos, y, fg, bg)
+		x_pos += style.StringOut("Navigate: ←h ↓j ↑k →l", x_pos, y)
 		x_pos = x + 10
-		x_pos += drawStringAtPoint("←←←←b w→→→→", x_pos, y+1, fg, bg)
+		x_pos += style.StringOut("←←←←b w→→→→", x_pos, y+1)
 	} else if pressure == 1 {
-		x_pos += drawStringAtPoint("Navigate: ←h ↓j", x_pos, y, fg, bg)
+		x_pos += style.StringOut("Navigate: ←h ↓j", x_pos, y)
 		x_pos = x + 10
-		x_pos += drawStringAtPoint("↑k →l", x_pos, y+1, fg, bg)
+		x_pos += style.StringOut("↑k →l", x_pos, y+1)
 	}
 	return x_pos - x, 2
 }

--- a/widget_nav.go
+++ b/widget_nav.go
@@ -20,13 +20,13 @@ func (widget NavigationWidget) layoutUnderPressure(pressure int) (int, int) {
 func (widget NavigationWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int, style *Style) (int, int) {
 	x_pos := x
 	if pressure == 0 {
-		x_pos += style.StringOut("Navigate: ←h ↓j ↑k →l", x_pos, y)
+		x_pos += StringOut("Navigate: ←h ↓j ↑k →l", x_pos, y, style)
 		x_pos = x + 10
-		x_pos += style.StringOut("←←←←b w→→→→", x_pos, y+1)
+		x_pos += StringOut("←←←←b w→→→→", x_pos, y+1, style)
 	} else if pressure == 1 {
-		x_pos += style.StringOut("Navigate: ←h ↓j", x_pos, y)
+		x_pos += StringOut("Navigate: ←h ↓j", x_pos, y, style)
 		x_pos = x + 10
-		x_pos += style.StringOut("↑k →l", x_pos, y+1)
+		x_pos += StringOut("↑k →l", x_pos, y+1, style)
 	}
 	return x_pos - x, 2
 }

--- a/widget_offset.go
+++ b/widget_offset.go
@@ -13,16 +13,14 @@ func (widget OffsetWidget) layoutUnderPressure(pressure int) (int, int) {
 	return 18, 2
 }
 
-func (widget OffsetWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int, style Style) (int, int) {
+func (widget OffsetWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int, style *Style) (int, int) {
 	if pressure > 3 {
 		return 0, 0
 	}
-	fg := style.default_fg
-	bg := style.default_bg
 	if cursor.hex_mode {
-		drawStringAtPoint(fmt.Sprintf("Offset(:)  0x%x", cursor.pos), x, y, fg, bg)
+		style.StringOut(fmt.Sprintf("Offset(:)  0x%x", cursor.pos), x, y)
 	} else {
-		drawStringAtPoint(fmt.Sprintf("Offset(:)  %d", cursor.pos), x, y, fg, bg)
+		style.StringOut(fmt.Sprintf("Offset(:)  %d", cursor.pos), x, y)
 	}
-	return drawStringAtPoint(fmt.Sprintf("  Type :  %s", cursor.c_type()), x, y+1, fg, bg), 2
+	return style.StringOut(fmt.Sprintf("  Type :  %s", cursor.c_type()), x, y+1), 2
 }

--- a/widget_offset.go
+++ b/widget_offset.go
@@ -18,9 +18,9 @@ func (widget OffsetWidget) drawAtPoint(cursor Cursor, x int, y int, pressure int
 		return 0, 0
 	}
 	if cursor.hex_mode {
-		style.StringOut(fmt.Sprintf("Offset(:)  0x%x", cursor.pos), x, y)
+		StringOut(fmt.Sprintf("Offset(:)  0x%x", cursor.pos), x, y, style)
 	} else {
-		style.StringOut(fmt.Sprintf("Offset(:)  %d", cursor.pos), x, y)
+		StringOut(fmt.Sprintf("Offset(:)  %d", cursor.pos), x, y, style)
 	}
-	return style.StringOut(fmt.Sprintf("  Type :  %s", cursor.c_type()), x, y+1), 2
+	return StringOut(fmt.Sprintf("  Type :  %s", cursor.c_type()), x, y+1, style), 2
 }


### PR DESCRIPTION
added a json based style configuration which tree based.
each node may define BG and FG attributes. If FG / BG are not defined
the parent nodes are used.

This could also be used to let the user configure the style of the programm.

For example:

``` js
{
   "FG": 1,   // Application wide default foreground.
   "BG": 256, // and background.
   "Data": {
      "FG": 5 // but set a different color for the data screen. 
   }
}
```

for a full example have a look at `hecate_others.go`
