### PR TITLE
present and re-use last field value for searching.

### DIFF
--- a/field_editor.go
+++ b/field_editor.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"unicode"
 	"unicode/utf8"
 
@@ -10,10 +11,16 @@ import (
 type FieldEditor struct {
 	value      []byte
 	cursor_pos int
+	last_value string
 }
 
 func (field_editor *FieldEditor) handleKeyEvent(event termbox.Event) (string, bool) {
 	is_done := false
+
+	if event.Ch == 0 && utf8.RuneCount(field_editor.value) == 0 {
+		field_editor.value = []byte(field_editor.last_value)
+	}
+
 	if event.Key == termbox.KeyEnter {
 		is_done = true
 	} else if event.Key == termbox.KeyEsc {
@@ -44,4 +51,15 @@ func (field_editor *FieldEditor) handleKeyEvent(event termbox.Event) (string, bo
 		field_editor.cursor_pos++
 	}
 	return string(field_editor.value), is_done
+}
+
+func (field_editor *FieldEditor) drawFieldValueAtPoint(style Style, x, y int) int {
+	termbox.SetCursor(x+2+field_editor.cursor_pos, y)
+	if utf8.RuneCount(field_editor.value) > 0 || len(field_editor.last_value) == 0 {
+		return drawStringAtPoint(fmt.Sprintf(" %-10s ", field_editor.value), x+1, y,
+			style.field_editor_fg, style.field_editor_bg)
+	} else {
+		return drawStringAtPoint(fmt.Sprintf(" %-10s ", field_editor.last_value), x+1, y,
+			style.field_editor_last_fg, style.field_editor_last_bg)
+	}
 }

--- a/platform_linux.go
+++ b/platform_linux.go
@@ -44,6 +44,9 @@ func defaultStyle() Style {
 	style.field_editor_bg = style.default_fg
 	style.field_editor_fg = style.default_bg
 
+	style.field_editor_last_bg = style.rune_fg
+	style.field_editor_last_fg = style.default_fg
+
 	style.space_rune = '•'
 	style.filled_bit_rune = '◾'
 	style.empty_bit_rune = '◽'

--- a/platform_others.go
+++ b/platform_others.go
@@ -44,6 +44,9 @@ func defaultStyle() Style {
 	style.field_editor_bg = style.default_fg
 	style.field_editor_fg = style.default_bg
 
+	style.field_editor_last_bg = style.rune_fg
+	style.field_editor_last_fg = style.default_fg
+
 	style.space_rune = '•'
 	style.filled_bit_rune = '●'
 	style.empty_bit_rune = '○'

--- a/platform_windows.go
+++ b/platform_windows.go
@@ -34,6 +34,9 @@ func defaultStyle() Style {
 	style.field_editor_bg = style.default_fg
 	style.field_editor_fg = style.default_bg
 
+	style.field_editor_last_bg = style.rune_fg
+	style.field_editor_last_fg = style.default_fg
+
 	style.space_rune = '•'
 	style.filled_bit_rune = '●'
 	style.empty_bit_rune = '○'

--- a/style.go
+++ b/style.go
@@ -27,6 +27,9 @@ type Style struct {
 	field_editor_bg termbox.Attribute
 	field_editor_fg termbox.Attribute
 
+	field_editor_last_bg termbox.Attribute
+	field_editor_last_fg termbox.Attribute
+
 	about_logo_bg termbox.Attribute
 
 	filled_bit_rune rune

--- a/tab.go
+++ b/tab.go
@@ -184,7 +184,7 @@ func (tab *DataTab) handleKeyEvent(event termbox.Event) int {
 		if tab.is_searching {
 			tab.search_quit_channel <- true
 		}
-		tab.field_editor = new(FieldEditor)
+		tab.field_editor = &FieldEditor{ last_value: tab.prev_search }
 		tab.edit_mode = EditingSearch
 	} else if event.Ch == '@' {
 		if tab.show_date {
@@ -412,8 +412,7 @@ func (tab *DataTab) drawTab(style Style, vertical_offset int) {
 			x = (width - 10) / 2
 			y = height - widget_height - 1
 		}
-		termbox.SetCursor(x+2+tab.field_editor.cursor_pos, y)
-		drawStringAtPoint(fmt.Sprintf(" %-10s ", tab.field_editor.value), x+1, y,
-			style.field_editor_fg, style.field_editor_bg)
+
+		tab.field_editor.drawFieldValueAtPoint(style, x, y)
 	}
 }


### PR DESCRIPTION
This patch shows your prev search term when pressing `/`, and allows you to refine your search by moving the cursor into it, at which point it goes "live", or goes away if you start typing right away (it comes back if you empty your search field)
