### PR TITLE
Use RuneWidth instead of increment

### DIFF
--- a/screen_about.go
+++ b/screen_about.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/nsf/termbox-go"
 )
 
@@ -154,7 +155,7 @@ func (screen *AboutScreen) drawScreen(style Style) {
 				}
 				termbox.SetCell(x_pos, y_pos, displayRune, default_fg, bg)
 			}
-			x_pos++
+			x_pos += runewidth.RuneWidth(displayRune)
 		}
 		y_pos++
 	}

--- a/string_util.go
+++ b/string_util.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/mattn/go-runewidth"
 	"github.com/nsf/termbox-go"
 )
 
@@ -20,7 +21,7 @@ func drawStringAtPoint(str string, x int, y int, fg termbox.Attribute, bg termbo
 	x_pos := x
 	for _, runeValue := range str {
 		termbox.SetCell(x_pos, y, runeValue, fg, bg)
-		x_pos++
+		x_pos += runewidth.RuneWidth(runeValue)
 	}
 	return x_pos - x
 }


### PR DESCRIPTION
CJK characters have full-width.
For instance, when this app reads Japanese name file, 
The tab's title wiil be broken.

```
$ ./hecate ~/こんにちは世界.jpg   
```

![hecate_fix01](https://cloud.githubusercontent.com/assets/1822861/18910077/5c8ccadc-85b1-11e6-92d6-9841995996c1.png)
