### PR TITLE
Fix build on Go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/evanmiller/hecate
 
+go 1.18
+
 require (
 	github.com/edsrzf/mmap-go v1.0.0
 	github.com/mattn/go-runewidth v0.0.4
 	github.com/nsf/termbox-go v0.0.0-20190104133558-0938b5187e61
-	golang.org/x/sys v0.0.0-20190108104531-7fbe1cd0fcc2 // indirect
 )
+
+require golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,3 +6,5 @@ github.com/nsf/termbox-go v0.0.0-20190104133558-0938b5187e61 h1:pEzZYac/uQ4cgaN1
 github.com/nsf/termbox-go v0.0.0-20190104133558-0938b5187e61/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
 golang.org/x/sys v0.0.0-20190108104531-7fbe1cd0fcc2 h1:ku9Kvp2ZBWAz3GyvuUH3UV1bZCd7RxH0Qf1epWfIDKc=
 golang.org/x/sys v0.0.0-20190108104531-7fbe1cd0fcc2/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Hey @evanmiller, thanks for this awesome tool! I noticed that it fails to build on OSX using Go 1.18 and I managed to resolve it as described in this StackOverflow post: https://stackoverflow.com/questions/71507321/go-1-18-build-error-on-mac-unix-syscall-darwin-1-13-go253-golinkname-mus

Also, since go modules are the default mode of operation now, I think the Readme could use some improvements for the build instructions. For example, I'd consider releasing a new tag for this project and then people could run `go install github.com/evanmiller/hecate@latest` to install it. Please let me know if you need any help with that.